### PR TITLE
Remove deprecated App Insights output (propagation from #18)

### DIFF
--- a/.propagation/infra-eval-20250810T000434Z.json
+++ b/.propagation/infra-eval-20250810T000434Z.json
@@ -1,0 +1,1 @@
+{"sourcePr":"https://github.com/Azure-Samples/functions-quickstart-dotnet-azd/pull/18","evaluation":"no-op","checked":["infra/main.bicep"],"reason":"output absent","timestamp":"2025-08-10T00:04:34Z"}

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -331,7 +331,6 @@ output USER_ASSIGNED_IDENTITY_PRINCIPAL_ID string = apiUserAssignedIdentity.outp
 output USER_ASSIGNED_IDENTITY_NAME string = apiUserAssignedIdentity.outputs.name
 
 // App outputs
-output APPLICATIONINSIGHTS_CONNECTION_STRING string = monitoring.outputs.connectionString
 output AZURE_KEY_VAULT_ENDPOINT string = enableSQLScripts ? db.outputs.keyVaultUri : ''
 output AZURE_KEY_VAULT_NAME string = enableSQLScripts ? db.outputs.keyVaultName : ''
 output AZURE_LOCATION string = location


### PR DESCRIPTION
Removes the deprecated APPLICATIONINSIGHTS_CONNECTION_STRING output from infra/main.bicep per https://github.com/Azure-Samples/functions-quickstart-dotnet-azd/pull/18

This change aligns the template with the source PR which removed this deprecated output pattern across Azure Functions AZD templates.